### PR TITLE
Changed "data transfer" mode to "data sharing"

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -37,6 +37,6 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Save Archive"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -51,7 +51,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Archive Built Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: |
           draft-*.html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,6 @@ jobs:
         make: upload
 
     - name: "Archive Submitted Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: "versioned/draft-*-[0-9][0-9].*"

--- a/draft-ietf-satp-architecture.md
+++ b/draft-ietf-satp-architecture.md
@@ -412,9 +412,9 @@ where a successful asset transfer causes the asset
 to be extinguished in the origin network and be created (generated)
 at the destination network.
 
- * Data transfer: This refers to the transfer of data only under authorization,
+ * Data sharing: This refers to the sharing of data only under authorization,
 in such a way that the data can be verified by a third party.
-The data transfer mode addresses the use-cases where
+The data sharing mode addresses the use-cases where
 the state update in one network or system depends on the existence of state information
 recorded in a different network or system.
 


### PR DESCRIPTION
- The term "data transfer" for one of the canonical interoperability modes in Section 4 is misleading, as the data is not meant to moved from one network to another but rather shared between the two. Hence, "sharing" is a more accurate term.
  - I'd originally proposed this taxonomy based on our experience building interoperability tools under the Hyperledger (now LFDT) Weaver and Cacti frameworks, and we'd changed "transfer" to "sharing" in those projects several years ago (based on feedback) to avoid confusion. See the Cacti docs for reference(https://github.com/hyperledger-cacti/cacti, https://hyperledger-cacti.github.io/cacti/weaver/interoperability-modes/).
- I've also upgraded the `upload-artifact` GitHub action to `v4` to fix the failing workflows (it was `v3` earlier, which is now deprecated).